### PR TITLE
fix(rune-table): avoid out of bound exception if there is no extra ingredients placed

### DIFF
--- a/src/main/java/com/sammy/malum/common/blocks/runetable/RuneTableTileEntity.java
+++ b/src/main/java/com/sammy/malum/common/blocks/runetable/RuneTableTileEntity.java
@@ -135,9 +135,16 @@ public class RuneTableTileEntity extends MultiblockTileEntity implements ITickab
                 }
             }
         }
+        if (stacks.isEmpty())
+        {
+            // There's no extra ingredients, ignore this assembly
+            return;
+        }
         ItemStack centerStack = inventory.getStackInSlot(0);
         if (!centerStack.isEmpty())
         {
+            // Insert ingredient on the main part of rune table to the specific position:
+            //   [extra, main, extra]
             stacks.add(1, centerStack);
         }
         MalumRuneTableRecipes.MalumRuneTableRecipe recipe = MalumRuneTableRecipes.getRecipe(stacks);


### PR DESCRIPTION
fix out of bound issue while assembling via rune table

logs:

```
[15:41:13] [Server thread/ERROR] [minecraft/MinecraftServer]: Encountered an unexpected exception
net.minecraft.crash.ReportedException: Ticking block entity
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:855) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A}
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:291) ~[?:?] {re:classloading,pl:accesstransformer:B}
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:787) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A}
        at net.minecraft.server.MinecraftServer.func_240802_v_(MinecraftServer.java:642) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A}
        at net.minecraft.server.MinecraftServer.func_240783_a_(MinecraftServer.java:232) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A}
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_292] {}
Caused by: java.lang.IndexOutOfBoundsException: Index: 1, Size: 0
        at java.util.ArrayList.rangeCheckForAdd(ArrayList.java:667) ~[?:1.8.0_292] {}
        at java.util.ArrayList.add(ArrayList.java:479) ~[?:1.8.0_292] {}
        at com.sammy.malum.common.blocks.runetable.RuneTableTileEntity.assemble(RuneTableTileEntity.java:141) ~[malum:1.16.5-0.3.0] {re:classloading}
        at com.sammy.malum.common.rites.ActivatorRite.executeRite(ActivatorRite.java:26) ~[malum:1.16.5-0.3.0] {re:classloading}
        at com.sammy.malum.common.blocks.totem.TotemBaseTileEntity.riteComplete(TotemBaseTileEntity.java:165) ~[malum:1.16.5-0.3.0] {re:classloading}
        at com.sammy.malum.common.blocks.totem.TotemBaseTileEntity.func_73660_a(TotemBaseTileEntity.java:123) ~[malum:1.16.5-0.3.0] {re:classloading}
        at net.minecraft.world.World.func_217391_K(World.java:491) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
        at net.minecraft.world.server.ServerWorld.func_72835_b(ServerWorld.java:371) ~[?:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:immersiveengineering.mixins.json:coremods.ServerWorldMixin,pl:mixin:A,pl:runtimedistcleaner:A}
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:851) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A}
        ... 5 more
```